### PR TITLE
Fix for issue #7 'build warning: no return statement in function retu…

### DIFF
--- a/ros_reflexxes/src/RosReflexxesPositionInterface.cpp
+++ b/ros_reflexxes/src/RosReflexxesPositionInterface.cpp
@@ -24,6 +24,7 @@ bool RosReflexxesPositionInterface::init( ros::NodeHandle nh ) {
                 }
         }
         position_initialized_ = false; 
+        return true;
 }//RosReflexxesPositionInterface::RosReflexxesPositionInterface()
 
 bool RosReflexxesPositionInterface::load_parameters(std::string ns) {


### PR DESCRIPTION
…rning non-void' by adding a `return true;`.